### PR TITLE
Remove the "typedef uint64_t __be64" line because when you have amd64 arc

### DIFF
--- a/nbd.h
+++ b/nbd.h
@@ -18,7 +18,6 @@
 
 #include <stdint.h>
 typedef uint32_t __be32;
-typedef uint64_t __be64;
 typedef uint32_t u32;
 typedef uint64_t u64;
 


### PR DESCRIPTION
Remove the "typedef uint64_t __be64" line because when you have amd64 architecture make's going to error
